### PR TITLE
Bugfix: Remove anchor on respawn

### DIFF
--- a/Assets/scripts/Checkpoint/CheckpointManager.cs
+++ b/Assets/scripts/Checkpoint/CheckpointManager.cs
@@ -81,6 +81,7 @@ public class CheckpointManager : MonoBehaviour {
         balloon.transform.position += move;
 
         balloon.GetComponent<balloon>().th = respawnPosition.y;
+        balloon.GetComponent<balloon>().anchored = false;
         GameObject.Find("player").GetComponent<player>().inBalloon = true;
         lastCheckpointScene = SceneManager.GetActiveScene().name;
     }


### PR DESCRIPTION
This fixes an issue where the balloon would be pulled to where the anchor was before death, typically straight into a spike creating the death loop of hell :smiley: 