### PR TITLE
Landing pad fixes

### DIFF
--- a/Assets/Scenes/level 3.unity
+++ b/Assets/Scenes/level 3.unity
@@ -1635,7 +1635,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8258316343278912387, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 116.28
+      value: 116.22
       objectReference: {fileID: 0}
     - target: {fileID: 8258316343278912387, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scenes/level 3.unity
+++ b/Assets/Scenes/level 3.unity
@@ -1585,6 +1585,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 3eb19c46fa8e45c4986ffa3ddcd1106c, type: 2}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Size.y
+      value: 58.92016
+      objectReference: {fileID: 0}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Offset.y
+      value: 28.96008
+      objectReference: {fileID: 0}
     - target: {fileID: 6444352938574417063, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: InitialModule.rotation3D
       value: 1
@@ -14858,6 +14866,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 3eb19c46fa8e45c4986ffa3ddcd1106c, type: 2}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Size.y
+      value: 204.85757
+      objectReference: {fileID: 0}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Offset.y
+      value: 101.92879
+      objectReference: {fileID: 0}
     - target: {fileID: 6444352938574417063, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: InitialModule.rotation3D
       value: 1
@@ -21963,6 +21979,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 3eb19c46fa8e45c4986ffa3ddcd1106c, type: 2}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Size.y
+      value: 74.62804
+      objectReference: {fileID: 0}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Offset.y
+      value: 36.81402
+      objectReference: {fileID: 0}
     - target: {fileID: 6444352938574417063, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: InitialModule.rotation3D
       value: 1
@@ -32056,6 +32080,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 3eb19c46fa8e45c4986ffa3ddcd1106c, type: 2}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Size.y
+      value: 172.71115
+      objectReference: {fileID: 0}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Offset.y
+      value: 85.855576
+      objectReference: {fileID: 0}
     - target: {fileID: 6444352938574417063, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: InitialModule.rotation3D
       value: 1
@@ -39465,6 +39497,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 3eb19c46fa8e45c4986ffa3ddcd1106c, type: 2}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Size.y
+      value: 217.595
+      objectReference: {fileID: 0}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Offset.y
+      value: 108.2975
+      objectReference: {fileID: 0}
     - target: {fileID: 6444352938574417063, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: InitialModule.rotation3D
       value: 1
@@ -68843,6 +68883,14 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 3eb19c46fa8e45c4986ffa3ddcd1106c, type: 2}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Size.y
+      value: 43.394897
+      objectReference: {fileID: 0}
+    - target: {fileID: 2809734574075071891, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
+      propertyPath: m_Offset.y
+      value: 21.197449
+      objectReference: {fileID: 0}
     - target: {fileID: 6444352938574417063, guid: e42837ce529b48646ae4b18297aff8eb, type: 3}
       propertyPath: InitialModule.rotation3D
       value: 1


### PR DESCRIPTION
moves one of the landing pads so that the player doesnt catch the edge as much, and expands the checkpoint triggers for level 3 into the sky. All landing pads were also tested.